### PR TITLE
DDNSサービスをNo-IP→Mydnsへ変更

### DIFF
--- a/WebServer/WebConstants.h
+++ b/WebServer/WebConstants.h
@@ -1,12 +1,18 @@
+#define ArrayCnt(ary) (sizeof(ary)/sizeof(ary[0]))  // 配列要素数取得マクロ
 
-const String ddnsMySiteName = "example.com";
-const String ddnsHostName	= "dynupdate.no-ip.com";
-const String ddnsAuthCode = "bWFpbEBleGFtcGxlLmNvbTpwYXNzd29yZA==";	//BASE64に変換 mail@example.com:password→bWFpbEBleGFtcGxlLmNvbTpwYXNzd29yZA==
-const String ddnsMailAddress	= "mail@example.com";
+const int ddnsPort = 21;    // ポート番号(FTP)
+const String ddnsMySiteName = "example.com";    // 登録済みドメイン
+const String ddnsHostName = "ftp.mydns.jp"; // DDNSホストサーバ
+const String ddnsAuthUser = "username";  // DDNSログインユーザ名
+const String ddnsAuthPass = "password";  // DDNSログインパスワード
+const String ddnsRequestStrs[] = {  // リクエストメッセージ
+	"USER " + ddnsAuthUser,
+	"PASS " + ddnsAuthPass
+};
+
 
 // Ethernetアクセス用
 byte mac[] = {
 	0x00, 0x00, 0x00, 0x00, 0x00, 0x00	// EthernetシールドのMACアドレス
 };
 IPAddress ip(192, 168, 11, 99);			// EthernetシールドのローカルIPアドレス
-

--- a/WebServer/WebConstants.h
+++ b/WebServer/WebConstants.h
@@ -10,7 +10,6 @@ const String ddnsRequestStrs[] = {  // リクエストメッセージ
 	"PASS " + ddnsAuthPass
 };
 
-
 // Ethernetアクセス用
 byte mac[] = {
 	0x00, 0x00, 0x00, 0x00, 0x00, 0x00	// EthernetシールドのMACアドレス


### PR DESCRIPTION
#2 利用するDDNSサービスを変更しました。
以下MyDNSを選択した理由
・IP通知以外のドメイン維持のための手動操作がieServerと同様に不要である
・FTPログインが使える他、対応している認証方法が多い(POP、IMAP、FTP、HTTP(S))
・Telnetで認証を行う都合上、HTTPよりFTPログインは実装が単純(BASE64エンコードが不要)
・無料ドメイン名に気に入るのがあった